### PR TITLE
Fix theme switcher script path

### DIFF
--- a/home/home.nix
+++ b/home/home.nix
@@ -21,7 +21,8 @@ in
   # --- Theme Switcher Script ---
   home.file.".local/bin/theme-switcher" = {
     executable = true;
-    source = ../nixos-theme-switcher-script.nix;
+    # Reference the actual script file
+    source = ../nixos-theme-switcher.nix;
   };
 
   # --- Correct Hyprland Configuration for Home Manager ---


### PR DESCRIPTION
## Summary
- correct the path to the theme switcher script

## Testing
- `shellcheck nixos-theme-switcher.nix`
- `nix flake check` *(fails: `nix` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68743aa1e32c8327a7fbcefdc6116326